### PR TITLE
more robust -- use latest rstudio-server instead of pointing to fixed…

### DIFF
--- a/Developing_on_Databricks/Customizing.md
+++ b/Developing_on_Databricks/Customizing.md
@@ -41,8 +41,8 @@ script = """
     sudo apt-get update
     sudo apt-get install -y gdebi-core alien
     cd /tmp
-    sudo wget https://download2.rstudio.org/rstudio-server-1.1.453-amd64.deb
-    sudo gdebi -n rstudio-server-1.1.453-amd64.deb
+    sudo wget https://www.rstudio.org/download/latest/stable/server/${UBUNTU_CODENAME}/rstudio-server-latest-amd64.deb
+    sudo gdebi -n rstudio-server-*-amd64.deb
     sudo rstudio-server restart
     exit 0
   else


### PR DESCRIPTION
… version

the `${UBUNTU_CODENAME}` part might be overkill. IIUC DB Runtime 6.5 is using `xenial`, that might just be hardcoded instead. Borrowed this URL from `rocker`:

https://github.com/rocker-org/rocker-versioned/blob/master/rstudio/3.6.3.Dockerfile